### PR TITLE
- added z/OS 2.3 required X-CSRF-ZOSMF-HEADER header into SdkApi class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,8 @@ in.txt
 tests/validation_tests/*
 config.py
 test.py
+
+
+
+# IDE stuff
+/.idea/

--- a/src/core/zowe/core_for_zowe_sdk/sdk_api.py
+++ b/src/core/zowe/core_for_zowe_sdk/sdk_api.py
@@ -36,7 +36,8 @@ class SdkApi:
         self.constants = constants
         self.default_service_url = default_url
         self.default_headers = {
-            "Content-type": "application/json"
+            "Content-type": "application/json",
+            "X-CSRF-ZOSMF-HEADER": ""
         }
         self.request_endpoint = "https://{base_url}{service}".format(
             base_url=self.connection.host_url, service=self.default_service_url

--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
@@ -89,7 +89,7 @@ class Files(SdkApi):
         custom_args = self.create_custom_request_arguments()
         custom_args["url"] = "{}ds/{}".format(self.request_endpoint, dataset_name)
         custom_args["data"] = data
-        custom_args["headers"] = {"Content-Type": "text/plain"}
+        custom_args['headers']['Content-Type'] = 'text/plain'
         response_json = self.request_handler.perform_request(
             "PUT", custom_args, expected_code=[204, 201]
         )

--- a/src/zos_jobs/zowe/zos_jobs_for_zowe_sdk/jobs.py
+++ b/src/zos_jobs/zowe/zos_jobs_for_zowe_sdk/jobs.py
@@ -150,7 +150,7 @@ class Jobs(SdkApi):
         """
         custom_args = self.create_custom_request_arguments()
         custom_args["data"] = str(jcl)
-        custom_args["headers"] = {"Content-Type": "text/plain"}
+        custom_args['headers']['Content-Type'] = 'text/plain'
         response_json = self.request_handler.perform_request(
             "PUT", custom_args, expected_code=[201]
         )


### PR DESCRIPTION
- changed custom headers override in Files and Jobs to preserve default headers we don't want to change


Initial fix for CSRF you created won't work in most cases, since you didn't modify SdkApi. Jobs and Files classes are based on SdkApi class and call self.create_custom_request_arguments() in every method which will lead to a request.